### PR TITLE
revert to Virchow class_token for dense pathology tasks

### DIFF
--- a/src/unicorn_baseline/vision/pathology/models.py
+++ b/src/unicorn_baseline/vision/pathology/models.py
@@ -96,7 +96,7 @@ class Virchow(nn.Module):
     Tile-level feature extractor.
     """
 
-    def __init__(self, model_dir, input_size=224, mode="full"):
+    def __init__(self, model_dir, mode: str, input_size=224):
         super().__init__()
         self.model_dir = model_dir
         self.input_size = input_size
@@ -153,16 +153,15 @@ class Virchow(nn.Module):
 
         if self.mode == "full":
             return embedding
-    
+
         elif self.mode == "patch_tokens":
             return patch_tokens
-        
+
         elif self.mode == "class_token":
             return class_token
 
         else:
-            return embedding    
-
+            raise ValueError(f"Unknown mode: {self.mode}. Choose from 'full', 'patch_tokens', or 'class_token'.")
 
 class PRISM(SlideFeatureExtractor):
     """

--- a/src/unicorn_baseline/vision_language/main.py
+++ b/src/unicorn_baseline/vision_language/main.py
@@ -115,7 +115,7 @@ def run_vision_language_task(*, input_information, model_dir):
         save_dir=coordinates_dir,
     )
 
-    tile_encoder = Virchow(model_dir=model_dir)
+    tile_encoder = Virchow(model_dir=model_dir, mode="full")
     prism = PRISM(model_dir=model_dir)
 
     caption = generate_caption(


### PR DESCRIPTION
- needed to be able to run a submission on `check-all` and `validation-all` leaderboard without having to wait for new adaptor capable of handling patch tokens
- additionally increased max number of tiles as PRISM if more memory efficient than TITAN (embedding speed is about 120 tiles / s, so 14k tiles took 2min, and 30k tiles shoukd take 4min 10s)